### PR TITLE
fix: portfolio audit updates — 4+ years, lead title, hero copy, locat…

### DIFF
--- a/projects/links/src/app/components/home/home.component.html
+++ b/projects/links/src/app/components/home/home.component.html
@@ -12,7 +12,7 @@
       </a>
       <h1 class="profile-name">Arshdeep Singh</h1>
       <p class="profile-handle">&#64;arshdeepgrover</p>
-      <p class="profile-title">Full Stack Developer</p>
+      <p class="profile-title">Lead Full-Stack Developer</p>
       <p class="profile-email">arshdeepgroverdev&#64;gmail.com</p>
       
       <div class="profile-actions">

--- a/projects/portfolio/src/app/components/contact/contact.component.html
+++ b/projects/portfolio/src/app/components/contact/contact.component.html
@@ -55,7 +55,7 @@
               </div>
               <div class="method-content">
                 <h4>Location</h4>
-                <p>New Delhi, Punjab</p>
+                <p>Delhi NCR &amp; Punjab, India</p>
                 <span class="method-note">Available for remote work</span>
               </div>
             </div>

--- a/projects/portfolio/src/app/components/hero/hero.component.html
+++ b/projects/portfolio/src/app/components/hero/hero.component.html
@@ -34,19 +34,19 @@
           <span #typedElement></span><span class="typing-cursor">|</span>
         </p>
         <p class="hero-description" data-aos="fade-up" data-aos-delay="200">
-          Passionate Full-Stack Developer with 3+ years of experience building
-          scalable web applications using Angular, Ruby on Rails, and modern technologies.
-          From crafting interactive web apps to developing Ruby gems and Chrome extensions,
-          I create solutions that solve real-world problems. Experienced in leading projects
-          from concept to deployment with focus on clean code and user experience.
+          Lead Full-Stack Developer with 4+ years building production-scale web applications
+          at Commudle — a platform serving 50,000+ users. Specialising in Angular and Ruby on Rails,
+          with hands-on delivery of payment integrations, headless CMS workflows, and real-time
+          analytics pipelines. I lead Agile sprints, mentor developers, and ship features
+          end-to-end — from concept to deployment.
         </p>
         <div class="hero-highlights" data-aos="fade-up" data-aos-delay="250">
           <div class="highlight-item">
-            <span class="highlight-number">3+</span>
+            <span class="highlight-number">4+</span>
             <span class="highlight-text">Years Experience</span>
           </div>
           <div class="highlight-item">
-            <span class="highlight-number">15+</span>
+            <span class="highlight-number">10+</span>
             <span class="highlight-text">Projects Delivered</span>
           </div>
           <div class="highlight-item">
@@ -68,26 +68,17 @@
         </div>
         <div class="hero-actions" data-aos="fade-up" data-aos-delay="275">
           <a href="#projects" class="hero-button"> View Projects </a>
-          <!-- <a
-            href="https://calendly.com/arshdeepgrover"
+          <a
+            href="https://topmate.io/arshdeepgrover"
             target="_blank"
             class="meeting-button"
           >
-            <svg
-              class="button-icon"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-              ></path>
+            <svg class="button-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
             </svg>
             Book a Meeting
-          </a> -->
+          </a>
           <a
             href="https://links.arshdeepgrover.dev?utm_source=portfolio&utm_medium=hero&utm_campaign=navigation"
             target="_blank"

--- a/projects/portfolio/src/app/components/hero/hero.component.ts
+++ b/projects/portfolio/src/app/components/hero/hero.component.ts
@@ -29,7 +29,7 @@ export class HeroComponent implements OnInit, OnDestroy {
     // Role typing animation
     this.typed = new Typed(this.typedElement.nativeElement, {
       strings: [
-        'Full Stack Developer',
+        'Lead Full-Stack Developer',
         'Angular Developer', 
         'Ruby on Rails Developer',
         'Hackathon Mentor & Judge',

--- a/projects/portfolio/src/app/stores/projects_store.ts
+++ b/projects/portfolio/src/app/stores/projects_store.ts
@@ -10,7 +10,7 @@ export const projects: IProject[] = [
     technologies: [
       'Angular',
       'Tailwind CSS',
-      'Web Application ',
+      'Web Application',
       'TypeScript',
       'Vercel',
       'Trivia',
@@ -28,7 +28,7 @@ export const projects: IProject[] = [
     technologies: [
       'Angular',
       'Tailwind CSS',
-      'OMDb API ',
+      'OMDb API',
       'TypeScript',
       'Vercel',
       'Movie Search',
@@ -55,7 +55,7 @@ export const projects: IProject[] = [
   },
   {
     id: 4,
-    title: '🚀 Groupix Spinner - A Customizable Web App',
+    title: 'Groupix Spinner - A Customizable Web App',
     description:
       'Groupix Spinner is a lightweight, zero-dependency spinner (loader) component library designed to improve user experience during loading states in modern web applications. It provides developers with a suite of vibrant, responsive, and highly customizable CSS-based loading animations that can be easily integrated into Web App project.',
     image: '/project-images/groupix-spinner.gif',


### PR DESCRIPTION
…ion, projects store

- hero.component.html: rewrite description (Lead Dev, 4+ yrs, 50k users)
- hero.component.html: update highlights — 4+ years, 10+ projects
- hero.component.html: replace commented Calendly with TopMate booking link
- hero.component.ts: first typed string → 'Lead Full-Stack Developer'
- contact.component.html: fix location 'New Delhi, Punjab' → 'Delhi NCR & Punjab, India'
- projects_store.ts: remove emoji from Groupix Spinner title, fix trailing spaces in tech tags
- links/home.component.html: profile title → 'Lead Full-Stack Developer'