### PR TITLE
feat: add personal bio to About section

### DIFF
--- a/projects/portfolio/src/app/components/about/about.component.html
+++ b/projects/portfolio/src/app/components/about/about.component.html
@@ -2,11 +2,24 @@
   <div class="about-container">
     <div class="about-header">
       <h2 class="about-title" data-aos="fade-up">
-        Work <span class="title-highlight">Experience</span>
+        About <span class="title-highlight">Me</span>
       </h2>
     </div>
 
+    <div class="about-bio" data-aos="fade-up" data-aos-delay="100">
+      <p class="bio-text">
+        I&#39;m a Lead Full-Stack Developer based in Delhi NCR, India. I joined
+        <a href="https://www.commudle.com" target="_blank" class="bio-link">Commudle</a>
+        as an intern in 2022 and grew into the Lead Developer role — shipping payment
+        integrations, headless CMS workflows, and real-time analytics pipelines on a platform
+        now serving 50,000+ people. I care about clean architecture, mentoring developers,
+        and building things that actually work end&#8209;to&#8209;end. Currently open to
+        Senior and Lead SDE roles.
+      </p>
+    </div>
+
     <div class="experience-section" data-aos="fade-up">
+      <h3 class="section-sub-title" data-aos="fade-up">Work Experience</h3>
       <div class="timeline">
         <div
           *ngFor="let exp of experiences; let i = index"

--- a/projects/portfolio/src/app/components/about/about.component.scss
+++ b/projects/portfolio/src/app/components/about/about.component.scss
@@ -110,3 +110,20 @@
 .position-description {
   @apply text-gray-600 dark:text-gray-400 mt-1 text-sm leading-relaxed;
 }
+
+// ── Personal Bio ─────────────────────────────────────────────────────────────
+.about-bio {
+  @apply mb-10;
+
+  .bio-text {
+    @apply text-gray-600 dark:text-gray-300 text-base leading-relaxed max-w-3xl;
+  }
+
+  .bio-link {
+    @apply font-medium text-blue-600 dark:text-blue-400 hover:underline;
+  }
+}
+
+.section-sub-title {
+  @apply text-xl font-semibold text-gray-800 dark:text-gray-200 mb-6;
+}


### PR DESCRIPTION
- Rename section heading from 'Work Experience' to 'About Me'
- Add bio paragraph: intern → Lead journey, Commudle, 50k users, open to roles
- Add 'Work Experience' sub-heading before the timeline
- Add .about-bio and .section-sub-title styles (Tailwind @apply)