### PR TITLE
feat: revamp hero section buttons

### DIFF
--- a/projects/portfolio/src/app/components/hero/hero.component.html
+++ b/projects/portfolio/src/app/components/hero/hero.component.html
@@ -34,10 +34,11 @@
           <span #typedElement></span><span class="typing-cursor">|</span>
         </p>
         <p class="hero-description" data-aos="fade-up" data-aos-delay="200">
-          Lead Full-Stack Developer with 4+ years building production-scale web applications
-          at Commudle — a platform serving 50,000+ users. Specialising in Angular and Ruby on Rails,
-          with hands-on delivery of payment integrations, headless CMS workflows, and real-time
-          analytics pipelines. I lead Agile sprints, mentor developers, and ship features
+          Lead Full-Stack Developer with 4+ years building production-scale web
+          applications at Commudle — a platform serving 50,000+ users.
+          Specialising in Angular and Ruby on Rails, with hands-on delivery of
+          payment integrations, headless CMS workflows, and real-time analytics
+          pipelines. I lead Agile sprints, mentor developers, and ship features
           end-to-end — from concept to deployment.
         </p>
         <div class="hero-highlights" data-aos="fade-up" data-aos-delay="250">
@@ -67,17 +68,41 @@
           </div>
         </div>
         <div class="hero-actions" data-aos="fade-up" data-aos-delay="275">
-          <a href="#projects" class="hero-button"> View Projects </a>
+          <a href="#projects" class="hero-button">
+            <span>View Projects</span>
+            <svg
+              class="btn-arrow"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M17 8l4 4m0 0l-4 4m4-4H3"
+              />
+            </svg>
+          </a>
           <a
             href="https://topmate.io/arshdeepgrover"
             target="_blank"
             class="meeting-button"
           >
-            <svg class="button-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            <svg
+              class="button-icon"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
             </svg>
-            Book a Meeting
+            <span>Book a Meeting</span>
           </a>
           <a
             href="https://links.arshdeepgrover.dev?utm_source=portfolio&utm_medium=hero&utm_campaign=navigation"
@@ -95,9 +120,9 @@
                 stroke-linejoin="round"
                 stroke-width="2"
                 d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.826a4 4 0 015.656 0l4 4a4 4 0 01-5.656 5.656l-1.1-1.1"
-              ></path>
+              />
             </svg>
-            My Links
+            <span>My Links</span>
           </a>
           <a
             href="/resume/Arshdeep_Singh_SoftwareDeveloper_Resume.pdf"
@@ -115,9 +140,9 @@
                 stroke-linejoin="round"
                 stroke-width="2"
                 d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-              ></path>
+              />
             </svg>
-            Download Resume
+            <span>Download Resume</span>
           </a>
         </div>
         <div class="hero-social" data-aos="fade-up" data-aos-delay="350">

--- a/projects/portfolio/src/app/components/hero/hero.component.scss
+++ b/projects/portfolio/src/app/components/hero/hero.component.scss
@@ -277,51 +277,76 @@
 }
 
 .hero-actions {
-  @apply flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center md:justify-start;
+  @apply flex flex-wrap gap-3 justify-center md:justify-start;
 }
 
 .hero-button {
-  @apply px-6 py-3 bg-primary text-white rounded-md transition-colors duration-300;
+  @apply inline-flex items-center gap-2 px-6 py-3 bg-primary text-white font-semibold rounded-lg transition-all duration-300;
+  box-shadow: 0 4px 20px rgba(255, 121, 85, 0.35);
+
+  .btn-arrow {
+    @apply w-4 h-4 flex-shrink-0 transition-transform duration-300;
+  }
 
   &:hover {
-    @apply bg-primary-dark;
+    @apply -translate-y-0.5;
+    box-shadow: 0 8px 28px rgba(255, 121, 85, 0.55);
+
+    .btn-arrow {
+      @apply translate-x-1;
+    }
+  }
+
+  &:active {
+    @apply scale-95;
   }
 }
 
 .meeting-button {
-  @apply inline-flex items-center px-6 py-3 bg-green-600 text-white rounded-md transition-colors duration-300;
+  @apply inline-flex items-center gap-2 px-6 py-3 bg-emerald-500 text-white font-semibold rounded-lg transition-all duration-300;
+  box-shadow: 0 4px 16px rgba(16, 185, 129, 0.25);
 
   &:hover {
-    @apply bg-green-700;
+    @apply bg-emerald-600 -translate-y-0.5;
+    box-shadow: 0 8px 22px rgba(16, 185, 129, 0.4);
   }
-}
 
-.email-button {
-  @apply inline-flex items-center px-6 py-3 bg-blue-600 text-white rounded-md transition-colors duration-300;
-
-  &:hover {
-    @apply bg-blue-700;
-  }
-}
-
-.resume-button {
-  @apply inline-flex items-center px-6 py-3 bg-transparent border-2 border-primary text-primary rounded-md transition-all duration-300;
-
-  &:hover {
-    @apply bg-primary text-white;
+  &:active {
+    @apply scale-95;
   }
 }
 
 .links-button {
-  @apply inline-flex items-center px-6 py-3 bg-indigo-600 text-white rounded-md transition-all duration-300 shadow-lg shadow-indigo-600/20;
+  @apply inline-flex items-center gap-2 px-6 py-3 border-2 border-indigo-500 text-indigo-600 dark:text-indigo-400 font-semibold rounded-lg bg-transparent transition-all duration-300;
 
   &:hover {
-    @apply bg-indigo-700 -translate-y-1 shadow-indigo-600/40;
+    @apply bg-indigo-500 text-white -translate-y-0.5;
+    box-shadow: 0 8px 22px rgba(99, 102, 241, 0.35);
+  }
+
+  &:active {
+    @apply scale-95;
+  }
+}
+
+.resume-button {
+  @apply inline-flex items-center gap-2 px-6 py-3 border-2 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-semibold rounded-lg bg-transparent transition-all duration-300;
+
+  &:hover {
+    @apply border-primary text-primary -translate-y-0.5 bg-primary/5;
+  }
+
+  &:active {
+    @apply scale-95;
   }
 }
 
 .button-icon {
-  @apply w-4 h-4 mr-2;
+  @apply w-4 h-4 flex-shrink-0;
+}
+
+.btn-arrow {
+  @apply w-4 h-4 flex-shrink-0;
 }
 
 .hero-social {


### PR DESCRIPTION
## Summary
- Replaced flat, inconsistent button styles with a cohesive modern design system
- **View Projects** — orange glow shadow with animated arrow that slides right on hover
- **Book a Meeting** — emerald green with lift + glow on hover
- **My Links** — outlined indigo that fills solid on hover
- **Download Resume** — neutral outline that highlights primary color on hover
- All buttons get `scale-95` on click for tactile feedback, `rounded-lg`, and `font-semibold`
- Switched `.hero-actions` to `flex-wrap` for better responsive behavior

## Test plan
- [ ] Visit `/` and check all four hero buttons render correctly in light and dark mode
- [ ] Verify hover effects (lift, glow, arrow slide) on each button
- [ ] Check responsive layout on mobile, tablet, and desktop
- [ ] Confirm all links still navigate correctly (Projects anchor, Topmate, Links hub, Resume PDF)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)