### PR TITLE
fix: studio app — TopMate booking, copy accuracy, stats

### DIFF
--- a/projects/studio/src/app/components/about/about.component.html
+++ b/projects/studio/src/app/components/about/about.component.html
@@ -35,8 +35,7 @@
 
         <p class="about-text" data-aos="fade-up" data-aos-delay="100">
           Arshdeep Studio is a premium design vertical focused on crafting high-fidelity 
-          digital products. Founded in 2022, we've helped dozens of brands transition from 
-          ideas to market leaders through meticulous UX research and cutting-edge visual design.
+          digital products. Founded in 2022, we've helped brands and startups go from idea to launched product — through strategic UX research, clean visual design, and end-to-end development.
         </p>
       </div>
 

--- a/projects/studio/src/app/components/contact/contact.component.html
+++ b/projects/studio/src/app/components/contact/contact.component.html
@@ -21,7 +21,7 @@
             <span class="detail-icon">📅</span>
             <div>
               <p class="detail-label">Book a Meeting</p>
-              <a [href]="contact.calendly" target="_blank" class="detail-value">{{ contact.calendly.replace('https://', '') }}</a>
+              <a [href]="contact.calendly" target="_blank" class="detail-value">{{ 'topmate.io/arshdeepgrover' }}</a>
             </div>
           </div>
         </div>

--- a/projects/studio/src/app/stores/contact_store.ts
+++ b/projects/studio/src/app/stores/contact_store.ts
@@ -1,6 +1,6 @@
 export const CONTACT_INFO = {
   email: 'arshdeepgroverdev@gmail.com',
-  calendly: 'https://calendly.com/arshdeepgrover',
+  calendly: 'https://topmate.io/arshdeepgrover',
   linksHub: 'https://links.arshdeepgrover.dev',
   socials: [
     { name: 'LinkedIn', url: 'https://linkedin.com/in/ArshdeepGrover' },

--- a/projects/studio/src/app/stores/stats_store.ts
+++ b/projects/studio/src/app/stores/stats_store.ts
@@ -10,7 +10,7 @@ export const HERO_STATS: IStat[] = [
     label: 'Happy Clients'
   },
   {
-    number: '~4',
+    number: '4+',
     label: 'Years Experience'
   }
 ];


### PR DESCRIPTION
- contact_store: replace Calendly with TopMate booking link
- contact.html: fix calendly URL display
- about.html: replace 'dozens of brands' with accurate, grounded copy
- stats_store: '~4' years → '4+' (consistent with portfolio)