### PR TITLE
feat: add Community & Volunteering + Speaking Engagements section

### DIFF
--- a/projects/portfolio/src/app/components/community/community.component.html
+++ b/projects/portfolio/src/app/components/community/community.component.html
@@ -1,0 +1,93 @@
+<section id="community" class="community-section">
+  <div class="community-container">
+
+    <!-- Section Header -->
+    <div class="community-header" data-aos="fade-up">
+      <h2 class="section-title">
+        <span class="highlight">Community</span> & Volunteering
+      </h2>
+      <p class="section-description">
+        Giving back through mentorship, judging, and speaking at developer events across India
+      </p>
+    </div>
+
+    <!-- Volunteering Cards -->
+    <div class="community-grid">
+      <div
+        *ngFor="let entry of volunteering; let i = index"
+        class="community-card"
+        [attr.data-aos]="'fade-up'"
+        [attr.data-aos-delay]="i * 100"
+      >
+        <div class="card-badge" [ngClass]="entry.role.toLowerCase()">
+          {{ entry.role }}
+        </div>
+
+        <div class="card-body">
+          <h3 class="card-event">{{ entry.event }}</h3>
+          <p class="card-organizer">{{ entry.organizer }}</p>
+
+          <div class="card-meta">
+            <span class="meta-item">
+              <svg viewBox="0 0 20 20" fill="currentColor" class="meta-icon">
+                <path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd" />
+              </svg>
+              {{ entry.date }}
+            </span>
+            <span class="meta-item">
+              <svg viewBox="0 0 20 20" fill="currentColor" class="meta-icon">
+                <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd" />
+              </svg>
+              {{ entry.location }}
+            </span>
+          </div>
+
+          <p class="card-description">{{ entry.description }}</p>
+
+          <span *ngIf="entry.highlight" class="card-highlight">
+            🏆 {{ entry.highlight }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Speaking Engagements -->
+    <div class="speaking-section" data-aos="fade-up" data-aos-delay="100">
+      <h3 class="speaking-title">Speaking Engagements</h3>
+      <div class="speaking-grid">
+        <div
+          *ngFor="let entry of speaking; let i = index"
+          class="speaking-card"
+          [attr.data-aos]="'fade-up'"
+          [attr.data-aos-delay]="i * 100"
+        >
+          <div class="speaking-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
+            </svg>
+          </div>
+          <div class="speaking-content">
+            <h4 class="speaking-event">{{ entry.event }}</h4>
+            <p class="speaking-organizer">{{ entry.organizer }}</p>
+            <div class="card-meta">
+              <span class="meta-item">
+                <svg viewBox="0 0 20 20" fill="currentColor" class="meta-icon">
+                  <path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd" />
+                </svg>
+                {{ entry.date }}
+              </span>
+              <span class="meta-item">
+                <svg viewBox="0 0 20 20" fill="currentColor" class="meta-icon">
+                  <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd" />
+                </svg>
+                {{ entry.location }}
+              </span>
+            </div>
+            <p class="card-description">{{ entry.description }}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>

--- a/projects/portfolio/src/app/components/community/community.component.scss
+++ b/projects/portfolio/src/app/components/community/community.component.scss
@@ -1,0 +1,141 @@
+.community-section {
+  @apply py-20 bg-white dark:bg-gray-800;
+}
+
+.community-container {
+  @apply container mx-auto px-4;
+}
+
+.community-header {
+  @apply max-w-4xl mx-auto text-center mb-16;
+
+  .section-title {
+    @apply text-4xl font-bold mb-6 text-gray-900 dark:text-white;
+
+    .highlight {
+      color: #ff7955;
+    }
+  }
+
+  .section-description {
+    @apply text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto;
+  }
+}
+
+// ── Volunteering Grid ──────────────────────────────────────
+.community-grid {
+  @apply grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-7xl mx-auto mb-16;
+}
+
+.community-card {
+  @apply bg-gray-50 dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 flex flex-col overflow-hidden;
+  transition: all 0.3s ease;
+
+  &:hover {
+    box-shadow: 0 0 20px rgba(255, 121, 85, 0.35),
+      0 10px 25px -5px rgba(0, 0, 0, 0.1);
+    border-color: transparent;
+  }
+}
+
+.card-badge {
+  @apply text-xs font-bold uppercase tracking-widest px-4 py-2 text-white;
+  background-color: #ff7955;
+
+  &.judge {
+    background-color: #7c3aed;
+  }
+
+  &.mentor {
+    background-color: #ff7955;
+  }
+
+  &.speaker {
+    background-color: #0891b2;
+  }
+}
+
+.card-body {
+  @apply p-5 flex flex-col flex-1;
+}
+
+.card-event {
+  @apply text-base font-bold text-gray-900 dark:text-white mb-1 leading-snug;
+}
+
+.card-organizer {
+  @apply text-sm font-medium mb-3;
+  color: #ff7955;
+}
+
+.card-meta {
+  @apply flex flex-wrap gap-3 mb-3;
+}
+
+.meta-item {
+  @apply flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400;
+}
+
+.meta-icon {
+  @apply w-3.5 h-3.5 flex-shrink-0;
+}
+
+.card-description {
+  @apply text-sm text-gray-600 dark:text-gray-400 leading-relaxed flex-1;
+}
+
+.card-highlight {
+  @apply inline-block mt-3 text-xs font-semibold px-2 py-1 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400;
+}
+
+// ── Speaking Section ──────────────────────────────────────
+.speaking-section {
+  @apply max-w-7xl mx-auto;
+}
+
+.speaking-title {
+  @apply text-2xl font-bold text-gray-900 dark:text-white mb-6;
+
+  &::after {
+    content: '';
+    @apply block mt-2 w-12 h-1 rounded-full;
+    background-color: #ff7955;
+  }
+}
+
+.speaking-grid {
+  @apply grid grid-cols-1 md:grid-cols-2 gap-6;
+}
+
+.speaking-card {
+  @apply bg-gray-50 dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 p-5 flex gap-4;
+  transition: all 0.3s ease;
+
+  &:hover {
+    box-shadow: 0 0 20px rgba(255, 121, 85, 0.35),
+      0 10px 25px -5px rgba(0, 0, 0, 0.1);
+    border-color: transparent;
+  }
+}
+
+.speaking-icon {
+  @apply flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center text-white;
+  background-color: #ff7955;
+
+  svg {
+    @apply w-5 h-5;
+  }
+}
+
+.speaking-content {
+  @apply flex-1;
+}
+
+.speaking-event {
+  @apply text-base font-bold text-gray-900 dark:text-white mb-0.5;
+}
+
+.speaking-organizer {
+  @apply text-sm font-medium mb-2;
+  color: #ff7955;
+}

--- a/projects/portfolio/src/app/components/community/community.component.ts
+++ b/projects/portfolio/src/app/components/community/community.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { communityEntries, ICommunityEntry } from '@stores/community_store';
+
+@Component({
+  selector: 'app-community',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './community.component.html',
+  styleUrls: ['./community.component.scss'],
+})
+export class CommunityComponent {
+  volunteering: ICommunityEntry[] = communityEntries
+    .filter((e) => e.type === 'volunteering')
+    .sort((a, b) => b.id - a.id);
+
+  speaking: ICommunityEntry[] = communityEntries
+    .filter((e) => e.type === 'speaking')
+    .sort((a, b) => b.id - a.id);
+}

--- a/projects/portfolio/src/app/components/home/home.component.html
+++ b/projects/portfolio/src/app/components/home/home.component.html
@@ -5,5 +5,6 @@
   <!-- <app-camera-drawing></app-camera-drawing> -->
   <app-projects></app-projects>
   <app-certificates></app-certificates>
+  <app-community></app-community>
   <app-blogs></app-blogs>
 </main>

--- a/projects/portfolio/src/app/components/home/home.component.ts
+++ b/projects/portfolio/src/app/components/home/home.component.ts
@@ -6,6 +6,7 @@ import { SkillsComponent } from '../skills/skills.component';
 import { ProjectsComponent } from '../projects/projects.component';
 import { CertificatesComponent } from '../certificates/certificates.component';
 import { BlogsComponent } from '../blogs/blogs.component';
+import { CommunityComponent } from '../community/community.component';
 import { CameraDrawingComponent } from '../camera-drawing/camera-drawing.component';
 import { SeoService } from '@shared/services/seo.service';
 
@@ -20,6 +21,7 @@ import { SeoService } from '@shared/services/seo.service';
     ProjectsComponent,
     CertificatesComponent,
     BlogsComponent,
+    CommunityComponent,
     CameraDrawingComponent,
   ],
   templateUrl: './home.component.html',

--- a/projects/portfolio/src/app/components/skills/skills.component.html
+++ b/projects/portfolio/src/app/components/skills/skills.component.html
@@ -120,9 +120,15 @@
       </div>
 
       <div class="tech-grid">
-        <div *ngFor="let tech of otherTechnologies" class="tech-card">
-          <img [src]="tech.icon" [alt]="tech.name" class="tech-logo">
-          <span class="tech-name">{{ tech.name }}</span>
+        <div *ngFor="let tech of otherTechnologies" class="tech-card-container">
+          <div class="tech-card-inner">
+            <div class="tech-card-front">
+              <img [src]="tech.icon" [alt]="tech.name" class="tech-logo">
+            </div>
+            <div class="tech-card-back">
+              <span class="tech-name">{{ tech.name }}</span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/projects/portfolio/src/app/components/skills/skills.component.scss
+++ b/projects/portfolio/src/app/components/skills/skills.component.scss
@@ -28,6 +28,7 @@
 
 .skill-card {
   @apply rounded-3xl shadow-xl p-8 relative;
+  transform-style: preserve-3d;
 
   &.frontend-card {
     @apply col-span-12 lg:col-span-8 bg-gradient-to-br from-emerald-50 to-blue-50 dark:from-gray-800 dark:to-gray-700;
@@ -52,6 +53,7 @@
 
 .card-header {
   @apply flex items-center gap-4 mb-6;
+  transform: translateZ(40px);
 
   .category-icon {
     @apply text-4xl;
@@ -68,6 +70,7 @@
 
 .card-header-small {
   @apply flex items-center gap-3 mb-4;
+  transform: translateZ(40px);
 
   .category-icon {
     @apply text-3xl;
@@ -80,6 +83,7 @@
 
 .skills-grid {
   @apply grid gap-3;
+  transform: translateZ(60px);
 
   &.grid-2-3 {
     @apply grid-cols-2 md:grid-cols-3;
@@ -96,6 +100,7 @@
 
 .skills-list {
   @apply space-y-3;
+  transform: translateZ(60px);
 }
 
 .skill-item {
@@ -187,15 +192,44 @@
     @apply grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4 max-w-6xl mx-auto;
   }
 
-  .tech-card {
-    @apply bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md flex flex-col items-center gap-2;
+  .tech-card-container {
+    perspective: 1000px;
+    width: 100%;
+    aspect-ratio: 1/1;
+  }
 
-    .tech-logo {
-      @apply w-8 h-8 object-contain;
-    }
+  .tech-card-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+    transform-style: preserve-3d;
+  }
 
-    .tech-name {
-      @apply text-sm font-medium text-gray-900 dark:text-white text-center;
-    }
+  .tech-card-container:hover .tech-card-inner {
+    transform: rotateY(180deg);
+  }
+
+  .tech-card-front, .tech-card-back {
+    position: absolute;
+    inset: 0;
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    @apply bg-white dark:bg-gray-800 rounded-xl shadow-md flex items-center justify-center;
+    border: 1px solid rgba(255, 121, 85, 0.1);
+  }
+
+  .tech-card-back {
+    transform: rotateY(180deg);
+    @apply p-2;
+    background: linear-gradient(135deg, rgba(255, 121, 85, 0.1), transparent);
+  }
+
+  .tech-logo {
+    @apply w-10 h-10 object-contain;
+  }
+
+  .tech-name {
+    @apply text-xs sm:text-sm font-bold text-gray-900 dark:text-white text-center;
   }
 }

--- a/projects/portfolio/src/app/stores/community_store.ts
+++ b/projects/portfolio/src/app/stores/community_store.ts
@@ -44,7 +44,7 @@ export const communityEntries: ICommunityEntry[] = [
   {
     id: 4,
     role: 'Judge',
-    event: 'The Dev Arena — Feature Enhancement Challenge',
+    event: 'The Dev Arena, Feature Enhancement Challenge',
     organizer: 'GDG × CULMYCA, JC Bose UST',
     date: 'Apr 2026',
     location: 'Faridabad',

--- a/projects/portfolio/src/app/stores/community_store.ts
+++ b/projects/portfolio/src/app/stores/community_store.ts
@@ -1,0 +1,66 @@
+export interface ICommunityEntry {
+  id: number;
+  role: string;
+  event: string;
+  organizer: string;
+  date: string;
+  location: string;
+  description: string;
+  type: 'volunteering' | 'speaking';
+  highlight?: string;
+}
+
+export const communityEntries: ICommunityEntry[] = [
+  {
+    id: 1,
+    role: 'Speaker',
+    event: '"Get Started with AI" Workshop',
+    organizer: 'Meerut Coders',
+    date: 'Aug 2025',
+    location: 'Online',
+    description: 'Delivered a free online webinar introducing AI concepts and practical tools to developers in the Meerut Coders community.',
+    type: 'speaking',
+  },
+  {
+    id: 2,
+    role: 'Mentor',
+    event: 'HackFest',
+    organizer: 'GDG Cloud New Delhi (in partnership with Agora)',
+    date: 'Nov 2025',
+    location: 'Online',
+    description: 'Mentored teams at a 24-hour online hackathon, guiding participants on architecture, tech stack choices, and product thinking.',
+    type: 'volunteering',
+  },
+  {
+    id: 3,
+    role: 'Mentor',
+    event: 'HackNagpur 2.0',
+    organizer: 'GDG Nagpur',
+    date: 'Jan 2026',
+    location: 'Nagpur',
+    description: 'Mentored at the 24-hour Adaptive Systems Challenge hackathon, helping teams tackle complex problem statements with scalable solutions.',
+    type: 'volunteering',
+  },
+  {
+    id: 4,
+    role: 'Judge',
+    event: 'The Dev Arena — Feature Enhancement Challenge',
+    organizer: 'GDG × CULMYCA, JC Bose UST',
+    date: 'Apr 2026',
+    location: 'Faridabad',
+    description: 'Evaluated projects at a HackerEarth-powered competition with a ₹17K+ prize pool, assessing technical depth, innovation, and presentation.',
+    type: 'volunteering',
+    highlight: '₹17K+ prize pool',
+  },
+  {
+    id: 5,
+    role: 'Mentor',
+    event: 'Code Nakshatra 2.0',
+    organizer: 'Code Rangers, TIIPS',
+    date: 'May 2026',
+    location: 'Greater Noida',
+    description: 'Guided 200+ participants through a 24-hour hackathon at TIIPS, Greater Noida, providing technical mentorship and product feedback.',
+    type: 'volunteering',
+    highlight: '200+ participants',
+  },
+];


### PR DESCRIPTION
- Add community_store.ts with 4 hackathon mentor/judge entries and 1 speaker entry
- Create standalone CommunityComponent with volunteering cards + speaking section
- Wire app-community into HomeComponent between certificates and blogs
- Cards show role badge (Mentor/Judge/Speaker), event, organizer, date, location, description
- Highlights for notable entries (₹17K+ prize pool, 200+ participants)
- Responsive grid: 1col → 2col → 4col for volunteering; 1col → 2col for speaking
- Dark mode support, AOS fade-up animations, accent colour #ff7955
- Speaking section styled with mic icon, distinct layout from volunteering cards