### PR TITLE
feat: add blogs Angular app + Sanity Studio to monorepo

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -20,7 +20,9 @@
             "outputPath": "dist/portfolio",
             "index": "projects/portfolio/src/index.html",
             "browser": "projects/portfolio/src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [
+              "zone.js"
+            ],
             "tsConfig": "projects/portfolio/tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -30,7 +32,9 @@
               },
               "projects/portfolio/src/sitemap.xml"
             ],
-            "styles": ["projects/portfolio/src/styles.scss"],
+            "styles": [
+              "projects/portfolio/src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -75,7 +79,10 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
             "tsConfig": "projects/portfolio/tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -84,7 +91,9 @@
                 "input": "projects/portfolio/public"
               }
             ],
-            "styles": ["projects/portfolio/src/styles.scss"],
+            "styles": [
+              "projects/portfolio/src/styles.scss"
+            ],
             "scripts": []
           }
         }
@@ -108,7 +117,9 @@
             "outputPath": "dist/links",
             "index": "projects/links/src/index.html",
             "browser": "projects/links/src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [
+              "zone.js"
+            ],
             "tsConfig": "projects/links/tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -117,7 +128,9 @@
                 "input": "projects/links/public"
               }
             ],
-            "styles": ["projects/links/src/styles.scss"],
+            "styles": [
+              "projects/links/src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -162,7 +175,10 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
             "tsConfig": "projects/links/tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -171,7 +187,9 @@
                 "input": "projects/links/public"
               }
             ],
-            "styles": ["projects/links/src/styles.scss"],
+            "styles": [
+              "projects/links/src/styles.scss"
+            ],
             "scripts": []
           }
         }
@@ -216,7 +234,9 @@
             "outputPath": "dist/studio",
             "index": "projects/studio/src/index.html",
             "browser": "projects/studio/src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [
+              "zone.js"
+            ],
             "tsConfig": "projects/studio/tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -225,7 +245,9 @@
                 "input": "projects/studio/public"
               }
             ],
-            "styles": ["projects/studio/src/styles.scss"],
+            "styles": [
+              "projects/studio/src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -270,7 +292,10 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
             "tsConfig": "projects/studio/tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -279,7 +304,105 @@
                 "input": "projects/studio/public"
               }
             ],
-            "styles": ["projects/studio/src/styles.scss"],
+            "styles": [
+              "projects/studio/src/styles.scss"
+            ],
+            "scripts": []
+          }
+        }
+      }
+    },
+    "blogs": {
+      "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "scss",
+          "skipTests": true
+        }
+      },
+      "root": "projects/blogs",
+      "sourceRoot": "projects/blogs/src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:application",
+          "options": {
+            "outputPath": "dist/blogs",
+            "index": "projects/blogs/src/index.html",
+            "browser": "projects/blogs/src/main.ts",
+            "polyfills": [
+              "zone.js"
+            ],
+            "tsConfig": "projects/blogs/tsconfig.app.json",
+            "inlineStyleLanguage": "scss",
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "projects/blogs/public"
+              }
+            ],
+            "styles": [
+              "projects/blogs/src/styles.scss"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kB",
+                  "maximumError": "1MB"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "20kB",
+                  "maximumError": "25kB"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "buildTarget": "links:build:production"
+            },
+            "development": {
+              "buildTarget": "links:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n"
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
+            "tsConfig": "projects/blogs/tsconfig.spec.json",
+            "inlineStyleLanguage": "scss",
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "projects/blogs/public"
+              }
+            ],
+            "styles": [
+              "projects/blogs/src/styles.scss"
+            ],
             "scripts": []
           }
         }

--- a/projects/blogs-studio/README.md
+++ b/projects/blogs-studio/README.md
@@ -1,0 +1,56 @@
+# Arsh.blog — Sanity Studio
+
+This is the Sanity Studio for `blogs.arshdeepgrover.dev`.
+
+## Quick Setup (5 minutes)
+
+### 1. Create a Sanity project
+```bash
+cd projects/blogs-studio
+npm install
+npx sanity init --project-id YOUR_NEW_PROJECT_ID --dataset production
+```
+Or create one at [sanity.io/manage](https://sanity.io/manage).
+
+### 2. Update project ID in two places
+- `projects/blogs-studio/sanity.config.ts` → replace `YOUR_PROJECT_ID`
+- `projects/blogs/src/environments/environment.ts` → replace `YOUR_PROJECT_ID`
+- `projects/blogs/src/environments/environment.prod.ts` → add to Vercel env var `SANITY_PROJECT_ID`
+
+### 3. Add CORS origin
+In Sanity dashboard → API → CORS Origins → add `https://blogs.arshdeepgrover.dev`
+
+### 4. Run locally
+```bash
+cd projects/blogs-studio
+npm run dev
+# Studio opens at http://localhost:3333
+```
+
+### 5. Deploy Studio to sanity.studio (free hosting)
+```bash
+npm run deploy
+# Studio available at https://arshdeep-blogs-studio.sanity.studio
+```
+
+### 6. Deploy Studio to Vercel (optional — for custom domain)
+Add a separate Vercel project pointing to `projects/blogs-studio` as the root directory.
+
+## Schemas
+| Type | Purpose |
+|---|---|
+| `post` | Blog posts with portable text body, cover image, categories, SEO fields |
+| `author` | Author profile (name, bio, image) |
+| `category` | Tags with custom hex color for badge styling |
+
+## GROQ Cheatsheet
+```groq
+// All posts
+*[_type == "post"] | order(publishedAt desc)
+
+// Single post by slug
+*[_type == "post" && slug.current == "my-post"][0]
+
+// Posts by category
+*[_type == "post" && "angular" in categories[]->slug.current]
+```

--- a/projects/blogs-studio/package.json
+++ b/projects/blogs-studio/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "arshdeep-blogs-studio",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "sanity dev",
+    "build": "sanity build",
+    "deploy": "sanity deploy",
+    "deploy-graphql": "sanity graphql deploy"
+  },
+  "dependencies": {
+    "@sanity/vision": "^3.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "sanity": "^3.0.0",
+    "styled-components": "^6.0.0"
+  }
+}

--- a/projects/blogs-studio/sanity.config.ts
+++ b/projects/blogs-studio/sanity.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'sanity';
+import { structureTool } from 'sanity/structure';
+import { visionTool } from '@sanity/vision';
+import { schemaTypes } from './schemaTypes';
+
+// 👉 Replace with your Sanity project details after running: sanity init
+const projectId = process.env.SANITY_STUDIO_PROJECT_ID ?? 'YOUR_PROJECT_ID';
+const dataset = process.env.SANITY_STUDIO_DATASET ?? 'production';
+
+export default defineConfig({
+  name: 'arshdeep-blogs-studio',
+  title: 'Arsh.blog — Studio',
+  projectId,
+  dataset,
+  plugins: [
+    structureTool({
+      structure: (S) =>
+        S.list()
+          .title('Content')
+          .items([
+            S.listItem().title('Posts').child(S.documentTypeList('post').title('Posts')),
+            S.listItem().title('Authors').child(S.documentTypeList('author').title('Authors')),
+            S.listItem().title('Categories').child(S.documentTypeList('category').title('Categories')),
+          ]),
+    }),
+    visionTool(),
+  ],
+  schema: { types: schemaTypes },
+});

--- a/projects/blogs-studio/schemaTypes/author.ts
+++ b/projects/blogs-studio/schemaTypes/author.ts
@@ -1,0 +1,14 @@
+import { defineField, defineType } from 'sanity';
+
+export const author = defineType({
+  name: 'author',
+  title: 'Author',
+  type: 'document',
+  fields: [
+    defineField({ name: 'name', type: 'string', validation: (r) => r.required() }),
+    defineField({ name: 'slug', type: 'slug', options: { source: 'name' }, validation: (r) => r.required() }),
+    defineField({ name: 'image', type: 'image', options: { hotspot: true } }),
+    defineField({ name: 'bio', type: 'text', rows: 4 }),
+  ],
+  preview: { select: { title: 'name', media: 'image' } },
+});

--- a/projects/blogs-studio/schemaTypes/category.ts
+++ b/projects/blogs-studio/schemaTypes/category.ts
@@ -1,0 +1,17 @@
+import { defineField, defineType } from 'sanity';
+
+export const category = defineType({
+  name: 'category',
+  title: 'Category',
+  type: 'document',
+  fields: [
+    defineField({ name: 'title', type: 'string', validation: (r) => r.required() }),
+    defineField({ name: 'slug', type: 'slug', options: { source: 'title' }, validation: (r) => r.required() }),
+    defineField({
+      name: 'color',
+      type: 'string',
+      description: 'Hex color for the tag badge (e.g. #DD0031)',
+      initialValue: '#ff7955',
+    }),
+  ],
+});

--- a/projects/blogs-studio/schemaTypes/index.ts
+++ b/projects/blogs-studio/schemaTypes/index.ts
@@ -1,0 +1,5 @@
+import { post } from './post';
+import { author } from './author';
+import { category } from './category';
+
+export const schemaTypes = [post, author, category];

--- a/projects/blogs-studio/schemaTypes/post.ts
+++ b/projects/blogs-studio/schemaTypes/post.ts
@@ -1,0 +1,73 @@
+import { defineField, defineType } from 'sanity';
+
+export const post = defineType({
+  name: 'post',
+  title: 'Post',
+  type: 'document',
+  fields: [
+    defineField({ name: 'title', type: 'string', validation: (r) => r.required() }),
+    defineField({
+      name: 'slug',
+      type: 'slug',
+      options: { source: 'title', maxLength: 96 },
+      validation: (r) => r.required(),
+    }),
+    defineField({
+      name: 'author',
+      type: 'reference',
+      to: [{ type: 'author' }],
+    }),
+    defineField({
+      name: 'coverImage',
+      type: 'image',
+      options: { hotspot: true },
+      fields: [defineField({ name: 'alt', type: 'string', title: 'Alt text' })],
+    }),
+    defineField({ name: 'publishedAt', type: 'datetime', initialValue: () => new Date().toISOString() }),
+    defineField({ name: 'updatedAt', type: 'datetime' }),
+    defineField({ name: 'excerpt', type: 'text', rows: 3, validation: (r) => r.required().max(300) }),
+    defineField({
+      name: 'categories',
+      type: 'array',
+      of: [{ type: 'reference', to: [{ type: 'category' }] }],
+    }),
+    defineField({ name: 'readTime', type: 'number', description: 'Estimated reading time in minutes' }),
+    defineField({ name: 'featured', type: 'boolean', initialValue: false }),
+    defineField({
+      name: 'body',
+      type: 'array',
+      of: [
+        { type: 'block' },
+        {
+          type: 'image',
+          options: { hotspot: true },
+          fields: [defineField({ name: 'alt', type: 'string' })],
+        },
+        {
+          type: 'object',
+          name: 'code',
+          title: 'Code block',
+          fields: [
+            defineField({ name: 'language', type: 'string', options: { list: ['typescript', 'javascript', 'ruby', 'html', 'scss', 'css', 'bash', 'json', 'yaml', 'sql'] } }),
+            defineField({ name: 'filename', type: 'string' }),
+            defineField({ name: 'code', type: 'text', rows: 10 }),
+          ],
+          preview: { select: { title: 'filename', subtitle: 'language' } },
+        },
+      ],
+    }),
+    defineField({ name: 'seoTitle', type: 'string', description: 'Override page <title> for SEO' }),
+    defineField({ name: 'seoDescription', type: 'text', rows: 2, description: 'Override meta description' }),
+  ],
+  preview: {
+    select: { title: 'title', author: 'author.name', media: 'coverImage', date: 'publishedAt' },
+    prepare({ title, author, media, date }) {
+      return {
+        title,
+        subtitle: `${author ?? 'Unknown'} · ${date ? new Date(date).toLocaleDateString() : 'Draft'}`,
+        media,
+      };
+    },
+  },
+  orderings: [{ title: 'Published (newest first)', name: 'publishedDesc', by: [{ field: 'publishedAt', direction: 'desc' }] }],
+});

--- a/projects/blogs/src/app/app.component.ts
+++ b/projects/blogs/src/app/app.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+import { HeaderComponent } from './components/header/header.component';
+import { FooterComponent } from './components/footer/footer.component';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RouterOutlet, HeaderComponent, FooterComponent],
+  template: `
+    <app-header></app-header>
+    <main class="main-content">
+      <router-outlet></router-outlet>
+    </main>
+    <app-footer></app-footer>
+  `,
+  styles: [`
+    :host { display: flex; flex-direction: column; min-height: 100vh; }
+    .main-content { flex: 1; }
+  `],
+})
+export class AppComponent {}

--- a/projects/blogs/src/app/app.config.ts
+++ b/projects/blogs/src/app/app.config.ts
@@ -1,0 +1,12 @@
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { provideRouter, withComponentInputBinding, withViewTransitions } from '@angular/router';
+import { provideHttpClient, withFetch } from '@angular/common/http';
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes, withComponentInputBinding(), withViewTransitions()),
+    provideHttpClient(withFetch()),
+  ],
+};

--- a/projects/blogs/src/app/app.routes.ts
+++ b/projects/blogs/src/app/app.routes.ts
@@ -1,0 +1,24 @@
+import { Routes } from '@angular/router';
+
+export const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./components/home/home.component').then((m) => m.HomeComponent),
+  },
+  {
+    path: 'post/:slug',
+    loadComponent: () =>
+      import('./components/post/post.component').then((m) => m.PostComponent),
+  },
+  {
+    path: 'tags/:slug',
+    loadComponent: () =>
+      import('./components/tags/tags.component').then((m) => m.TagsComponent),
+  },
+  {
+    path: '**',
+    loadComponent: () =>
+      import('./components/not-found/not-found.component').then((m) => m.NotFoundComponent),
+  },
+];

--- a/projects/blogs/src/app/components/footer/footer.component.ts
+++ b/projects/blogs/src/app/components/footer/footer.component.ts
@@ -1,0 +1,41 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  template: `
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <p>© {{ year }} <a href="https://arshdeepgrover.dev" target="_blank">Arshdeep Singh</a> · Built with Angular + Sanity.io</p>
+        <div class="footer-links">
+          <a href="https://arshdeepgrover.dev" target="_blank">Portfolio</a>
+          <a href="https://links.arshdeepgrover.dev" target="_blank">Links</a>
+          <a href="https://github.com/ArshdeepGrover" target="_blank">GitHub</a>
+        </div>
+      </div>
+    </footer>
+  `,
+  styles: [`
+    .site-footer {
+      border-top: 1px solid rgba(255,255,255,0.07);
+      padding: 2rem 1.5rem;
+      margin-top: 4rem;
+    }
+    .footer-inner {
+      max-width: 900px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+    p, a { font-size: 0.85rem; color: rgba(255,255,255,0.35); text-decoration: none; }
+    a:hover { color: #ff7955; }
+    p a { color: rgba(255,255,255,0.5); }
+    .footer-links { display: flex; gap: 1.25rem; }
+  `],
+})
+export class FooterComponent {
+  year = new Date().getFullYear();
+}

--- a/projects/blogs/src/app/components/header/header.component.html
+++ b/projects/blogs/src/app/components/header/header.component.html
@@ -1,0 +1,17 @@
+<header class="site-header" [class.scrolled]="scrolled">
+  <div class="header-inner">
+    <a routerLink="/" class="logo">
+      <span class="logo-accent">A</span>rsh<span class="logo-accent">.</span>blog
+    </a>
+
+    <nav class="nav-links" [class.open]="menuOpen">
+      <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}" (click)="menuOpen=false">Home</a>
+      <a routerLink="/tags" routerLinkActive="active" (click)="menuOpen=false">Tags</a>
+      <a href="https://arshdeepgrover.dev" target="_blank" class="nav-external">Portfolio ↗</a>
+    </nav>
+
+    <button class="hamburger" (click)="toggleMenu()" [attr.aria-label]="menuOpen ? 'Close menu' : 'Open menu'">
+      <span></span><span></span><span></span>
+    </button>
+  </div>
+</header>

--- a/projects/blogs/src/app/components/header/header.component.scss
+++ b/projects/blogs/src/app/components/header/header.component.scss
@@ -1,0 +1,101 @@
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  transition: background 0.3s ease, box-shadow 0.3s ease, backdrop-filter 0.3s;
+
+  &.scrolled {
+    background: rgba(10, 10, 10, 0.85);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    box-shadow: 0 1px 0 rgba(255,255,255,0.06);
+  }
+}
+
+.header-inner {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.logo {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #fff;
+  text-decoration: none;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+
+  .logo-accent { color: #ff7955; }
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+  margin-left: auto;
+
+  a {
+    color: rgba(255,255,255,0.55);
+    text-decoration: none;
+    font-size: 0.9rem;
+    font-weight: 500;
+    transition: color 0.2s;
+
+    &:hover, &.active { color: #fff; }
+    &.active { color: #ff7955; }
+  }
+
+  .nav-external { color: rgba(255,255,255,0.4); font-size: 0.85rem; }
+}
+
+.hamburger {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  margin-left: auto;
+
+  span {
+    display: block;
+    width: 22px;
+    height: 2px;
+    background: rgba(255,255,255,0.7);
+    border-radius: 2px;
+    transition: all 0.25s;
+  }
+}
+
+@media (max-width: 640px) {
+  .hamburger { display: flex; }
+
+  .nav-links {
+    display: none;
+    position: absolute;
+    top: 64px;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    gap: 0;
+    background: rgba(10,10,10,0.97);
+    backdrop-filter: blur(20px);
+    padding: 1rem 0 1.5rem;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+
+    &.open { display: flex; }
+
+    a { padding: 0.75rem 1.5rem; width: 100%; }
+  }
+}

--- a/projects/blogs/src/app/components/header/header.component.ts
+++ b/projects/blogs/src/app/components/header/header.component.ts
@@ -1,0 +1,24 @@
+import { Component, HostListener } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [CommonModule, RouterLink, RouterLinkActive],
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss'],
+})
+export class HeaderComponent {
+  scrolled = false;
+  menuOpen = false;
+
+  @HostListener('window:scroll', [])
+  onScroll() {
+    this.scrolled = window.scrollY > 20;
+  }
+
+  toggleMenu() {
+    this.menuOpen = !this.menuOpen;
+  }
+}

--- a/projects/blogs/src/app/components/home/home.component.html
+++ b/projects/blogs/src/app/components/home/home.component.html
@@ -1,0 +1,105 @@
+<!-- Demo banner when Sanity is not yet connected -->
+<div *ngIf="isPlaceholder" class="demo-banner">
+  ✦ Demo mode — connect Sanity to publish real posts.
+  <a href="https://www.sanity.io/manage" target="_blank">Set up Sanity →</a>
+</div>
+
+<div class="blog-home">
+
+  <!-- Hero -->
+  <section class="blog-hero">
+    <div class="container">
+      <p class="hero-label">Writing & Thoughts</p>
+      <h1 class="hero-title">
+        Angular, Rails &amp; <span class="accent">everything</span> in between
+      </h1>
+      <p class="hero-sub">
+        Practical articles on full-stack development, team leadership, and open source —
+        by <a href="https://arshdeepgrover.dev" target="_blank" class="hero-link">Arshdeep Singh</a>.
+      </p>
+    </div>
+  </section>
+
+  <div class="container" *ngIf="!loading; else skeleton">
+
+    <!-- Featured post -->
+    <section *ngIf="featuredPost" class="featured-section">
+      <a [routerLink]="['/post', featuredPost.slug.current]" class="featured-card">
+        <div class="featured-cover">
+          <div class="featured-cover-placeholder">
+            <span class="cover-icon">✦</span>
+          </div>
+          <div class="featured-badge">Featured</div>
+        </div>
+        <div class="featured-body">
+          <div class="post-meta">
+            <span class="post-date">{{ formatDate(featuredPost.publishedAt) }}</span>
+            <span class="read-time" *ngIf="featuredPost.readTime">· {{ featuredPost.readTime }} min read</span>
+          </div>
+          <h2 class="featured-title">{{ featuredPost.title }}</h2>
+          <p class="featured-excerpt">{{ featuredPost.excerpt }}</p>
+          <div class="post-tags" *ngIf="featuredPost.categories?.length">
+            <span class="tag" *ngFor="let cat of featuredPost.categories"
+                  [style.--tag-color]="cat.color">{{ cat.title }}</span>
+          </div>
+          <span class="read-link">Read article →</span>
+        </div>
+      </a>
+    </section>
+
+    <!-- Category filter -->
+    <div class="filter-bar" *ngIf="categories.length">
+      <button class="filter-btn" [class.active]="activeCategory === 'all'"
+              (click)="setCategory('all')">All</button>
+      <button class="filter-btn" *ngFor="let cat of categories"
+              [class.active]="activeCategory === cat.slug"
+              [style.--tag-color]="cat.color"
+              (click)="setCategory(cat.slug)">{{ cat.title }}</button>
+    </div>
+
+    <!-- Posts grid -->
+    <section class="posts-grid" *ngIf="filteredPosts.length; else empty">
+      <a class="post-card" *ngFor="let post of filteredPosts; let i = index"
+         [routerLink]="['/post', post.slug.current]"
+         [style.animation-delay]="i * 0.06 + 's'">
+        <div class="card-cover">
+          <div class="card-cover-placeholder">
+            <span class="cover-icon">{{ getCoverEmoji(post) }}</span>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="post-meta">
+            <span class="post-date">{{ formatDate(post.publishedAt) }}</span>
+            <span class="read-time" *ngIf="post.readTime">· {{ post.readTime }} min</span>
+          </div>
+          <h3 class="card-title">{{ post.title }}</h3>
+          <p class="card-excerpt">{{ post.excerpt }}</p>
+          <div class="post-tags" *ngIf="post.categories?.length">
+            <span class="tag" *ngFor="let cat of post.categories"
+                  [style.--tag-color]="cat.color">{{ cat.title }}</span>
+          </div>
+        </div>
+      </a>
+    </section>
+
+    <ng-template #empty>
+      <div class="empty-state">No posts in this category yet.</div>
+    </ng-template>
+
+  </div>
+
+  <!-- Loading skeleton -->
+  <ng-template #skeleton>
+    <div class="container skeleton-grid">
+      <div class="skeleton-card" *ngFor="let n of [1,2,3,4,5,6]">
+        <div class="skeleton-cover"></div>
+        <div class="skeleton-body">
+          <div class="skeleton-line short"></div>
+          <div class="skeleton-line"></div>
+          <div class="skeleton-line medium"></div>
+        </div>
+      </div>
+    </div>
+  </ng-template>
+
+</div>

--- a/projects/blogs/src/app/components/home/home.component.scss
+++ b/projects/blogs/src/app/components/home/home.component.scss
@@ -1,0 +1,321 @@
+// ─── Demo banner ──────────────────────────────────────
+.demo-banner {
+  background: rgba(255, 121, 85, 0.1);
+  border-bottom: 1px solid rgba(255, 121, 85, 0.25);
+  color: rgba(255,255,255,0.7);
+  text-align: center;
+  font-size: 0.8rem;
+  padding: 0.6rem 1rem;
+  a { color: #ff7955; text-decoration: none; margin-left: 0.5rem; &:hover { text-decoration: underline; } }
+}
+
+// ─── Hero ──────────────────────────────────────────────
+.blog-hero {
+  padding: 8rem 1.5rem 4rem;
+  text-align: center;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(ellipse 60% 50% at 50% 0%,
+      rgba(255, 121, 85, 0.08) 0%, transparent 70%);
+    pointer-events: none;
+  }
+}
+
+.hero-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #ff7955;
+  margin-bottom: 1rem;
+}
+
+.hero-title {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 900;
+  color: #fff;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  margin-bottom: 1.25rem;
+  .accent { color: #ff7955; }
+}
+
+.hero-sub {
+  font-size: 1.05rem;
+  color: rgba(255,255,255,0.5);
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.hero-link { color: rgba(255,255,255,0.75); text-decoration: none; &:hover { color: #ff7955; } }
+
+// ─── Container ────────────────────────────────────────
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.blog-home { padding-bottom: 5rem; }
+
+// ─── Featured card ────────────────────────────────────
+.featured-section { margin: 3rem 0 2rem; }
+
+.featured-card {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 0;
+  border-radius: 20px;
+  overflow: hidden;
+  text-decoration: none;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.03);
+  transition: all 0.3s ease;
+
+  &:hover {
+    border-color: rgba(255, 121, 85, 0.35);
+    box-shadow: 0 0 40px rgba(255,121,85,0.1), 0 20px 60px rgba(0,0,0,0.3);
+    transform: translateY(-3px);
+    .featured-title { color: #ff7955; }
+  }
+
+  @media (max-width: 640px) { grid-template-columns: 1fr; }
+}
+
+.featured-cover {
+  position: relative;
+  min-height: 240px;
+  background: linear-gradient(135deg, #1a1a1a 0%, #111 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.featured-cover-placeholder {
+  .cover-icon { font-size: 4rem; opacity: 0.2; }
+}
+
+.featured-badge {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #ff7955;
+  background: rgba(255,121,85,0.12);
+  border: 1px solid rgba(255,121,85,0.3);
+  padding: 0.25rem 0.6rem;
+  border-radius: 6px;
+}
+
+.featured-body {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.featured-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #fff;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+  margin: 0.5rem 0 0.75rem;
+  transition: color 0.2s;
+}
+
+.featured-excerpt {
+  font-size: 0.9rem;
+  color: rgba(255,255,255,0.5);
+  line-height: 1.7;
+  flex: 1;
+  margin-bottom: 1rem;
+}
+
+.read-link {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #ff7955;
+  margin-top: auto;
+}
+
+// ─── Post meta ────────────────────────────────────────
+.post-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.post-date { font-size: 0.8rem; color: rgba(255,255,255,0.35); }
+.read-time { font-size: 0.8rem; color: rgba(255,255,255,0.35); }
+
+// ─── Tags ────────────────────────────────────────────
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.tag {
+  --tag-color: #ff7955;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.2rem 0.55rem;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--tag-color) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--tag-color) 30%, transparent);
+  color: var(--tag-color);
+}
+
+// ─── Filter bar ───────────────────────────────────────
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 2.5rem 0 1.75rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+
+.filter-btn {
+  --tag-color: #ff7955;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.35rem 0.85rem;
+  border-radius: 20px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.04);
+  color: rgba(255,255,255,0.45);
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover { color: rgba(255,255,255,0.8); border-color: rgba(255,255,255,0.2); }
+
+  &.active {
+    background: color-mix(in srgb, var(--tag-color) 15%, transparent);
+    border-color: color-mix(in srgb, var(--tag-color) 40%, transparent);
+    color: var(--tag-color);
+  }
+}
+
+// ─── Posts grid ───────────────────────────────────────
+.posts-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+
+  @media (max-width: 768px) { grid-template-columns: repeat(2, 1fr); }
+  @media (max-width: 480px) { grid-template-columns: 1fr; }
+}
+
+.post-card {
+  border-radius: 16px;
+  overflow: hidden;
+  text-decoration: none;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.03);
+  display: flex;
+  flex-direction: column;
+  animation: fadeSlideUp 0.5s ease both;
+  transition: all 0.3s ease;
+
+  &:hover {
+    border-color: rgba(255,121,85,0.3);
+    box-shadow: 0 8px 32px rgba(0,0,0,0.2), 0 0 20px rgba(255,121,85,0.08);
+    transform: translateY(-4px);
+
+    .card-title { color: #ff7955; }
+  }
+}
+
+@keyframes fadeSlideUp {
+  from { opacity: 0; transform: translateY(24px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.card-cover {
+  height: 140px;
+  background: linear-gradient(135deg, #161616 0%, #0f0f0f 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-cover-placeholder .cover-icon { font-size: 2.5rem; opacity: 0.18; }
+
+.card-body { padding: 1.25rem; flex: 1; display: flex; flex-direction: column; }
+
+.card-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: -0.01em;
+  line-height: 1.4;
+  margin-bottom: 0.5rem;
+  transition: color 0.2s;
+}
+
+.card-excerpt {
+  font-size: 0.8rem;
+  color: rgba(255,255,255,0.4);
+  line-height: 1.65;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+// ─── Empty + Skeletons ────────────────────────────────
+.empty-state {
+  text-align: center;
+  padding: 4rem;
+  color: rgba(255,255,255,0.3);
+  font-size: 0.9rem;
+}
+
+.skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+  margin-top: 4rem;
+  @media (max-width: 640px) { grid-template-columns: 1fr; }
+}
+
+.skeleton-card {
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.06);
+  background: rgba(255,255,255,0.02);
+}
+
+.skeleton-cover {
+  height: 140px;
+  background: linear-gradient(90deg, rgba(255,255,255,0.04) 25%, rgba(255,255,255,0.08) 50%, rgba(255,255,255,0.04) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.skeleton-body { padding: 1.25rem; display: flex; flex-direction: column; gap: 0.75rem; }
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 6px;
+  background: rgba(255,255,255,0.07);
+  &.short { width: 40%; }
+  &.medium { width: 70%; }
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/projects/blogs/src/app/components/home/home.component.ts
+++ b/projects/blogs/src/app/components/home/home.component.ts
@@ -1,0 +1,89 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { Post, Category } from '@models/post.model';
+import { SanityService } from '@services/sanity.service';
+import { MOCK_POSTS } from '../../services/mock-posts';
+import { environment } from '../../../environments/environment';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss'],
+})
+export class HomeComponent implements OnInit {
+  loading = true;
+  allPosts: Post[] = [];
+  featuredPost: Post | null = null;
+  recentPosts: Post[] = [];
+  categories: Category[] = [];
+  activeCategory = 'all';
+  isPlaceholder = false;
+
+  constructor(private sanity: SanityService) {}
+
+  ngOnInit() {
+    const isMockMode = environment.sanityProjectId === 'YOUR_PROJECT_ID';
+    if (isMockMode) {
+      this.loadMockData();
+    } else {
+      this.loadSanityData();
+    }
+  }
+
+  private loadMockData() {
+    this.isPlaceholder = true;
+    this.allPosts = MOCK_POSTS;
+    this.processPosts(MOCK_POSTS);
+  }
+
+  private loadSanityData() {
+    this.sanity.getPosts().subscribe((posts) => {
+      this.allPosts = posts;
+      this.processPosts(posts);
+    });
+    this.sanity.getCategories().subscribe((cats) => (this.categories = cats));
+  }
+
+  private processPosts(posts: Post[]) {
+    this.featuredPost = posts.find((p) => p.featured) ?? posts[0] ?? null;
+    this.recentPosts = posts.filter((p) => p._id !== this.featuredPost?._id);
+    // derive categories from posts
+    const catMap = new Map<string, Category>();
+    posts.forEach((p) => p.categories?.forEach((c) => catMap.set(c._id, c)));
+    this.categories = Array.from(catMap.values());
+    this.loading = false;
+  }
+
+  get filteredPosts(): Post[] {
+    if (this.activeCategory === 'all') return this.recentPosts;
+    return this.recentPosts.filter((p) =>
+      p.categories?.some((c) => c.slug === this.activeCategory),
+    );
+  }
+
+  setCategory(slug: string) {
+    this.activeCategory = slug;
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+  }
+
+  getCoverEmoji(post: Post): string {
+    const cat = post.categories?.[0]?.slug ?? '';
+    const map: Record<string, string> = {
+      angular: '🅰️', 'ruby-on-rails': '💎', payments: '💳',
+      analytics: '📊', cms: '🗂️', leadership: '🏆', career: '🚀',
+      ai: '🤖', performance: '⚡', packages: '📦',
+    };
+    return map[cat] ?? '✦';
+  }
+
+  imageUrl(ref: string | undefined, w = 800): string {
+    if (!ref) return '/images/blog-placeholder.jpg';
+    return this.sanity.imageUrl(ref, w);
+  }
+}

--- a/projects/blogs/src/app/components/not-found/not-found.component.ts
+++ b/projects/blogs/src/app/components/not-found/not-found.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-not-found',
+  standalone: true,
+  imports: [RouterLink],
+  template: `
+    <div style="text-align:center;padding:10rem 1.5rem">
+      <p style="font-size:5rem;margin-bottom:1rem">✦</p>
+      <h1 style="font-size:2rem;font-weight:900;color:#fff;margin-bottom:0.75rem">Page not found</h1>
+      <p style="color:rgba(255,255,255,0.4);margin-bottom:2rem">The post you're looking for doesn't exist.</p>
+      <a routerLink="/" style="color:#ff7955;font-weight:700;text-decoration:none">← Back to blog</a>
+    </div>
+  `,
+})
+export class NotFoundComponent {}

--- a/projects/blogs/src/app/components/post/post.component.html
+++ b/projects/blogs/src/app/components/post/post.component.html
@@ -1,0 +1,76 @@
+<!-- Loading -->
+<div *ngIf="loading" class="post-loading">
+  <div class="skeleton-title"></div>
+  <div class="skeleton-meta"></div>
+  <div class="skeleton-body">
+    <div class="skeleton-line" *ngFor="let n of [1,2,3,4,5]"></div>
+  </div>
+</div>
+
+<!-- Not found -->
+<div *ngIf="!loading && notFound" class="not-found-msg">
+  <p>Post not found.</p>
+  <a routerLink="/">← Back to blog</a>
+</div>
+
+<!-- Post -->
+<article *ngIf="!loading && post" class="post-article">
+
+  <!-- Back -->
+  <div class="post-nav">
+    <a routerLink="/" class="back-link">← All posts</a>
+  </div>
+
+  <!-- Header -->
+  <header class="post-header">
+    <div class="post-tags" *ngIf="post.categories?.length">
+      <span class="tag" *ngFor="let cat of post.categories"
+            [style.--tag-color]="cat.color">{{ cat.title }}</span>
+    </div>
+    <h1 class="post-title">{{ post.title }}</h1>
+    <p class="post-excerpt">{{ post.excerpt }}</p>
+    <div class="post-byline">
+      <div class="author-info" *ngIf="post.author">
+        <div class="author-avatar">{{ post.author.name[0] }}</div>
+        <span class="author-name">{{ post.author.name }}</span>
+      </div>
+      <span class="byline-sep">·</span>
+      <span class="post-date">{{ formatDate(post.publishedAt) }}</span>
+      <span class="byline-sep" *ngIf="post.readTime">·</span>
+      <span class="read-time" *ngIf="post.readTime">{{ post.readTime }} min read</span>
+      <button class="share-btn" (click)="share()" title="Share">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8"/>
+          <polyline points="16 6 12 2 8 6"/>
+          <line x1="12" y1="2" x2="12" y2="15"/>
+        </svg>
+      </button>
+    </div>
+  </header>
+
+  <!-- Cover image placeholder -->
+  <div class="post-cover-placeholder">
+    <span class="cover-glyph">✦</span>
+  </div>
+
+  <!-- Demo note -->
+  <div class="demo-note" *ngIf="!post.body">
+    <p>📝 This is a demo post. Connect Sanity to render full article content here.</p>
+    <a href="https://www.sanity.io/manage" target="_blank">Set up Sanity →</a>
+  </div>
+
+  <!-- Portable text body -->
+  <div class="post-body" *ngIf="post.body" [innerHTML]="post.body | portableText"></div>
+
+  <!-- Footer -->
+  <footer class="post-footer">
+    <div class="post-tags" *ngIf="post.categories?.length">
+      <span class="tag" *ngFor="let cat of post.categories"
+            [style.--tag-color]="cat.color">{{ cat.title }}</span>
+    </div>
+    <div class="back-cta">
+      <a routerLink="/" class="back-link">← Back to all posts</a>
+    </div>
+  </footer>
+
+</article>

--- a/projects/blogs/src/app/components/post/post.component.scss
+++ b/projects/blogs/src/app/components/post/post.component.scss
@@ -1,0 +1,253 @@
+.post-article, .post-loading, .not-found-msg {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 5rem 1.5rem 4rem;
+}
+
+// ─── Back link ────────────────────────────────────────
+.post-nav { margin-bottom: 2.5rem; }
+.back-link {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(255,255,255,0.4);
+  text-decoration: none;
+  transition: color 0.2s;
+  &:hover { color: #ff7955; }
+}
+
+// ─── Header ───────────────────────────────────────────
+.post-header {
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+
+.post-title {
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
+  font-weight: 900;
+  color: #fff;
+  letter-spacing: -0.03em;
+  line-height: 1.2;
+  margin: 1rem 0;
+}
+
+.post-excerpt {
+  font-size: 1.05rem;
+  color: rgba(255,255,255,0.5);
+  line-height: 1.7;
+  margin-bottom: 1.5rem;
+}
+
+.post-byline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.author-info { display: flex; align-items: center; gap: 0.5rem; }
+
+.author-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(255,121,85,0.2);
+  border: 1px solid rgba(255,121,85,0.4);
+  color: #ff7955;
+  font-size: 0.75rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.author-name { font-size: 0.85rem; font-weight: 600; color: rgba(255,255,255,0.7); }
+.byline-sep { color: rgba(255,255,255,0.2); font-size: 0.8rem; }
+.post-date, .read-time { font-size: 0.8rem; color: rgba(255,255,255,0.35); }
+
+.share-btn {
+  margin-left: auto;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 8px;
+  padding: 0.35rem;
+  cursor: pointer;
+  color: rgba(255,255,255,0.4);
+  display: flex;
+  transition: all 0.2s;
+  svg { width: 16px; height: 16px; }
+  &:hover { color: #ff7955; border-color: rgba(255,121,85,0.4); }
+}
+
+// ─── Tags ────────────────────────────────────────────
+.post-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.75rem; }
+.tag {
+  --tag-color: #ff7955;
+  font-size: 0.72rem; font-weight: 600;
+  padding: 0.2rem 0.55rem; border-radius: 5px;
+  background: color-mix(in srgb, var(--tag-color) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--tag-color) 30%, transparent);
+  color: var(--tag-color);
+}
+
+// ─── Cover placeholder ────────────────────────────────
+.post-cover-placeholder {
+  height: 280px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #161616 0%, #0f0f0f 100%);
+  border: 1px solid rgba(255,255,255,0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 3rem;
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(ellipse 60% 50% at 50% 50%,
+      rgba(255,121,85,0.06) 0%, transparent 70%);
+  }
+
+  .cover-glyph { font-size: 4rem; opacity: 0.12; }
+}
+
+// ─── Demo note ────────────────────────────────────────
+.demo-note {
+  background: rgba(255,121,85,0.06);
+  border: 1px solid rgba(255,121,85,0.2);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  text-align: center;
+  p { color: rgba(255,255,255,0.6); font-size: 0.9rem; margin-bottom: 0.75rem; }
+  a { color: #ff7955; font-size: 0.85rem; font-weight: 600; }
+}
+
+// ─── Post body (Portable Text) ────────────────────────
+.post-body {
+  color: rgba(255,255,255,0.8);
+  font-size: 1rem;
+  line-height: 1.8;
+
+  :global(.post-p) { margin: 0 0 1.5rem; }
+  :global(.post-h2) {
+    font-size: 1.5rem; font-weight: 800; color: #fff;
+    margin: 2.5rem 0 1rem; letter-spacing: -0.02em;
+    &::before { content: '# '; color: #ff7955; opacity: 0.5; font-weight: 400; }
+  }
+  :global(.post-h3) {
+    font-size: 1.2rem; font-weight: 700; color: #fff; margin: 2rem 0 0.75rem;
+  }
+  :global(.post-h1) { font-size: 1.75rem; font-weight: 900; color: #fff; margin: 2.5rem 0 1rem; }
+  :global(.post-h4) { font-size: 1rem; font-weight: 700; color: rgba(255,255,255,0.9); margin: 1.75rem 0 0.5rem; }
+
+  :global(.post-quote) {
+    border-left: 3px solid #ff7955;
+    padding: 0.75rem 1.25rem;
+    background: rgba(255,121,85,0.06);
+    border-radius: 0 8px 8px 0;
+    color: rgba(255,255,255,0.65);
+    font-style: italic;
+    margin: 1.5rem 0;
+  }
+
+  :global(.inline-code) {
+    font-family: 'Fira Code', 'Cascadia Code', monospace;
+    font-size: 0.875em;
+    background: rgba(255,255,255,0.08);
+    border: 1px solid rgba(255,255,255,0.12);
+    padding: 0.15em 0.4em;
+    border-radius: 4px;
+    color: #ff9f7d;
+  }
+
+  :global(.code-block) {
+    position: relative;
+    margin: 1.5rem 0;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid rgba(255,255,255,0.08);
+    background: #0d0d0d;
+  }
+
+  :global(.code-filename) {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: rgba(255,255,255,0.4);
+    padding: 0.6rem 1rem;
+    border-bottom: 1px solid rgba(255,255,255,0.07);
+    font-family: monospace;
+    background: rgba(255,255,255,0.02);
+  }
+
+  :global(.code-block pre) {
+    padding: 1.25rem;
+    overflow-x: auto;
+    margin: 0;
+  }
+
+  :global(.code-block code) {
+    font-family: 'Fira Code', 'Cascadia Code', 'Courier New', monospace;
+    font-size: 0.875rem;
+    line-height: 1.7;
+    color: #e2e8f0;
+  }
+
+  :global(.post-link) {
+    color: #ff7955;
+    text-decoration: underline;
+    text-decoration-color: rgba(255,121,85,0.3);
+    text-underline-offset: 3px;
+    transition: text-decoration-color 0.2s;
+    &:hover { text-decoration-color: #ff7955; }
+  }
+
+  :global(.post-image) {
+    margin: 2rem 0;
+    border-radius: 12px;
+    overflow: hidden;
+    img { width: 100%; height: auto; display: block; }
+  }
+}
+
+// ─── Footer ───────────────────────────────────────────
+.post-footer {
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(255,255,255,0.08);
+}
+
+.back-cta { margin-top: 1.5rem; }
+
+// ─── Skeleton ─────────────────────────────────────────
+.skeleton-title {
+  height: 2.5rem; border-radius: 8px;
+  background: rgba(255,255,255,0.07); margin-bottom: 1rem; width: 80%;
+}
+.skeleton-meta {
+  height: 1rem; width: 40%; border-radius: 6px;
+  background: rgba(255,255,255,0.05); margin-bottom: 3rem;
+}
+.skeleton-body { display: flex; flex-direction: column; gap: 0.75rem; }
+.skeleton-line {
+  height: 14px; border-radius: 6px;
+  background: linear-gradient(90deg, rgba(255,255,255,0.05) 25%, rgba(255,255,255,0.08) 50%, rgba(255,255,255,0.05) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  &:nth-child(even) { width: 85%; }
+}
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.not-found-msg {
+  text-align: center;
+  padding-top: 8rem;
+  p { color: rgba(255,255,255,0.5); margin-bottom: 1rem; }
+  a { color: #ff7955; text-decoration: none; font-weight: 600; }
+}

--- a/projects/blogs/src/app/components/post/post.component.ts
+++ b/projects/blogs/src/app/components/post/post.component.ts
@@ -1,0 +1,53 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink, ActivatedRoute } from '@angular/router';
+import { Post } from '@models/post.model';
+import { SanityService } from '@services/sanity.service';
+import { PortableTextPipe } from '../../pipes/portable-text.pipe';
+import { MOCK_POSTS } from '../../services/mock-posts';
+import { environment } from '../../../environments/environment';
+
+@Component({
+  selector: 'app-post',
+  standalone: true,
+  imports: [CommonModule, RouterLink, PortableTextPipe],
+  templateUrl: './post.component.html',
+  styleUrls: ['./post.component.scss'],
+})
+export class PostComponent implements OnInit {
+  post: Post | null = null;
+  loading = true;
+  notFound = false;
+
+  constructor(private route: ActivatedRoute, private sanity: SanityService) {}
+
+  ngOnInit() {
+    const slug = this.route.snapshot.paramMap.get('slug') ?? '';
+    const isMock = environment.sanityProjectId === 'YOUR_PROJECT_ID';
+
+    if (isMock) {
+      const found = MOCK_POSTS.find((p) => p.slug.current === slug);
+      this.post = found ?? null;
+      this.notFound = !found;
+      this.loading = false;
+    } else {
+      this.sanity.getPostBySlug(slug).subscribe((post) => {
+        this.post = post;
+        this.notFound = !post;
+        this.loading = false;
+      });
+    }
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+  }
+
+  share() {
+    if (navigator.share) {
+      navigator.share({ title: this.post?.title, url: window.location.href });
+    } else {
+      navigator.clipboard.writeText(window.location.href);
+    }
+  }
+}

--- a/projects/blogs/src/app/components/tags/tags.component.ts
+++ b/projects/blogs/src/app/components/tags/tags.component.ts
@@ -1,0 +1,72 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { Category, Post } from '@models/post.model';
+import { MOCK_POSTS } from '../../services/mock-posts';
+import { environment } from '../../../environments/environment';
+import { SanityService } from '@services/sanity.service';
+
+@Component({
+  selector: 'app-tags',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  template: `
+    <div class="tags-page">
+      <div class="container">
+        <h1 class="page-title">Browse by <span class="accent">Tag</span></h1>
+        <p class="page-sub">Filter articles by topic</p>
+
+        <div class="tags-grid">
+          <a class="tag-card" *ngFor="let cat of categories"
+             [routerLink]="['/']" [queryParams]="{category: cat.slug}"
+             [style.--tag-color]="cat.color">
+            <span class="tag-title">{{ cat.title }}</span>
+            <span class="tag-count">{{ getCount(cat.slug) }} post{{ getCount(cat.slug) !== 1 ? 's' : '' }}</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .tags-page { padding: 7rem 1.5rem 5rem; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .page-title { font-size: 2.5rem; font-weight: 900; color: #fff; letter-spacing: -0.03em; margin-bottom: 0.5rem; }
+    .accent { color: #ff7955; }
+    .page-sub { color: rgba(255,255,255,0.35); margin-bottom: 3rem; }
+    .tags-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 1rem; }
+    .tag-card {
+      --tag-color: #ff7955;
+      display: flex; flex-direction: column; gap: 0.4rem;
+      padding: 1.25rem 1.5rem; border-radius: 14px;
+      background: color-mix(in srgb, var(--tag-color) 8%, rgba(255,255,255,0.02));
+      border: 1px solid color-mix(in srgb, var(--tag-color) 25%, transparent);
+      text-decoration: none; transition: all 0.25s;
+      &:hover { transform: translateY(-3px); box-shadow: 0 8px 24px rgba(0,0,0,0.2); background: color-mix(in srgb, var(--tag-color) 14%, rgba(255,255,255,0.03)); }
+    }
+    .tag-title { font-size: 1rem; font-weight: 700; color: #fff; }
+    .tag-count { font-size: 0.78rem; color: rgba(255,255,255,0.4); }
+  `],
+})
+export class TagsComponent implements OnInit {
+  categories: Category[] = [];
+  posts: Post[] = [];
+
+  constructor(private sanity: SanityService) {}
+
+  ngOnInit() {
+    const isMock = environment.sanityProjectId === 'YOUR_PROJECT_ID';
+    if (isMock) {
+      this.posts = MOCK_POSTS;
+      const catMap = new Map<string, Category>();
+      MOCK_POSTS.forEach((p) => p.categories?.forEach((c) => catMap.set(c._id, c)));
+      this.categories = Array.from(catMap.values());
+    } else {
+      this.sanity.getCategories().subscribe((c) => (this.categories = c));
+      this.sanity.getPosts().subscribe((p) => (this.posts = p));
+    }
+  }
+
+  getCount(slug: string): number {
+    return this.posts.filter((p) => p.categories?.some((c) => c.slug === slug)).length;
+  }
+}

--- a/projects/blogs/src/app/models/post.model.ts
+++ b/projects/blogs/src/app/models/post.model.ts
@@ -1,0 +1,50 @@
+export interface SanityImage {
+  _type: 'image';
+  asset: { _ref: string; _type: 'reference' };
+  alt?: string;
+}
+
+export interface SanityBlock {
+  _type: 'block' | 'image' | 'code';
+  _key: string;
+  style?: string;
+  children?: Array<{ _type: 'span'; _key: string; text: string; marks?: string[] }>;
+  markDefs?: Array<{ _type: string; _key: string; href?: string }>;
+  // code block
+  language?: string;
+  code?: string;
+  filename?: string;
+  // image block
+  asset?: { _ref: string };
+  alt?: string;
+}
+
+export interface Author {
+  _id: string;
+  name: string;
+  slug: string;
+  image?: SanityImage;
+  bio?: string;
+}
+
+export interface Category {
+  _id: string;
+  title: string;
+  slug: string;
+  color?: string;
+}
+
+export interface Post {
+  _id: string;
+  title: string;
+  slug: { current: string };
+  author?: Author;
+  coverImage?: SanityImage;
+  publishedAt: string;
+  updatedAt?: string;
+  excerpt: string;
+  categories?: Category[];
+  body?: SanityBlock[];
+  readTime?: number;
+  featured?: boolean;
+}

--- a/projects/blogs/src/app/pipes/portable-text.pipe.ts
+++ b/projects/blogs/src/app/pipes/portable-text.pipe.ts
@@ -1,0 +1,68 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { SanityBlock } from '@models/post.model';
+
+@Pipe({ name: 'portableText', standalone: true })
+export class PortableTextPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(blocks: SanityBlock[] | undefined): SafeHtml {
+    if (!blocks?.length) return '';
+    const html = blocks.map((b) => this.renderBlock(b)).join('\n');
+    return this.sanitizer.bypassSecurityTrustHtml(html);
+  }
+
+  private renderBlock(block: SanityBlock): string {
+    // Code block
+    if (block._type === 'code') {
+      const lang = block.language ?? 'text';
+      const code = this.escape(block.code ?? '');
+      const file = block.filename ? `<span class="code-filename">${this.escape(block.filename)}</span>` : '';
+      return `<div class="code-block">${file}<pre><code class="language-${lang}">${code}</code></pre></div>`;
+    }
+
+    // Image block
+    if (block._type === 'image' && block.asset?._ref) {
+      const alt = this.escape(block.alt ?? '');
+      return `<figure class="post-image"><img src="${block.asset._ref}" alt="${alt}" loading="lazy" /></figure>`;
+    }
+
+    // Text block
+    if (block._type === 'block') {
+      const inner = (block.children ?? []).map((span) => {
+        let text = this.escape(span.text);
+        const marks = span.marks ?? [];
+        // Apply inline marks
+        if (marks.includes('strong')) text = `<strong>${text}</strong>`;
+        if (marks.includes('em')) text = `<em>${text}</em>`;
+        if (marks.includes('code')) text = `<code class="inline-code">${text}</code>`;
+        if (marks.includes('underline')) text = `<u>${text}</u>`;
+        // Links — find markDef
+        const linkMark = marks.find((m) => !['strong', 'em', 'code', 'underline', 'strike-through'].includes(m));
+        if (linkMark) {
+          const def = (block.markDefs ?? []).find((d) => d._key === linkMark);
+          if (def?.href) text = `<a href="${def.href}" target="_blank" rel="noopener noreferrer" class="post-link">${text}</a>`;
+        }
+        if (marks.includes('strike-through')) text = `<s>${text}</s>`;
+        return text;
+      }).join('');
+
+      const style = block.style ?? 'normal';
+      const map: Record<string, string> = {
+        h1: `<h1 class="post-h1">${inner}</h1>`,
+        h2: `<h2 class="post-h2">${inner}</h2>`,
+        h3: `<h3 class="post-h3">${inner}</h3>`,
+        h4: `<h4 class="post-h4">${inner}</h4>`,
+        blockquote: `<blockquote class="post-quote">${inner}</blockquote>`,
+        normal: `<p class="post-p">${inner}</p>`,
+      };
+      return map[style] ?? `<p class="post-p">${inner}</p>`;
+    }
+
+    return '';
+  }
+
+  private escape(str: string): string {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+}

--- a/projects/blogs/src/app/services/mock-posts.ts
+++ b/projects/blogs/src/app/services/mock-posts.ts
@@ -1,0 +1,88 @@
+import { Post } from '@models/post.model';
+
+export const MOCK_POSTS: Post[] = [
+  {
+    _id: '1',
+    title: 'Building Scalable Angular Apps with Signals and OnPush',
+    slug: { current: 'angular-signals-onpush' },
+    excerpt: 'Deep dive into Angular 17+ Signals, OnPush change detection, and how to architect apps that handle 50,000+ users without performance issues.',
+    publishedAt: '2025-08-15T09:00:00Z',
+    readTime: 8,
+    featured: true,
+    categories: [
+      { _id: 'c1', title: 'Angular', slug: 'angular', color: '#DD0031' },
+      { _id: 'c4', title: 'Performance', slug: 'performance', color: '#ff7955' },
+    ],
+    author: { _id: 'a1', name: 'Arshdeep Singh', slug: 'arshdeep-singh' },
+  },
+  {
+    _id: '2',
+    title: 'Razorpay Integration in Ruby on Rails — A Complete Guide',
+    slug: { current: 'razorpay-rails-integration' },
+    excerpt: 'Step-by-step guide to integrating Razorpay payment gateway in a Ruby on Rails app — webhooks, subscriptions, and error handling included.',
+    publishedAt: '2025-07-28T09:00:00Z',
+    readTime: 12,
+    featured: false,
+    categories: [
+      { _id: 'c2', title: 'Ruby on Rails', slug: 'ruby-on-rails', color: '#CC0000' },
+      { _id: 'c3', title: 'Payments', slug: 'payments', color: '#1DBF73' },
+    ],
+    author: { _id: 'a1', name: 'Arshdeep Singh', slug: 'arshdeep-singh' },
+  },
+  {
+    _id: '3',
+    title: 'Google Tag Manager for Single Page Applications',
+    slug: { current: 'gtm-spa-angular' },
+    excerpt: 'How to set up GTM in an Angular SPA without redeployments — virtual pageviews, custom events, and dataLayer patterns that actually work.',
+    publishedAt: '2025-06-10T09:00:00Z',
+    readTime: 7,
+    featured: false,
+    categories: [
+      { _id: 'c1', title: 'Angular', slug: 'angular', color: '#DD0031' },
+      { _id: 'c5', title: 'Analytics', slug: 'analytics', color: '#F9AB00' },
+    ],
+    author: { _id: 'a1', name: 'Arshdeep Singh', slug: 'arshdeep-singh' },
+  },
+  {
+    _id: '4',
+    title: 'Sanity.io + Ruby on Rails: Headless CMS in Practice',
+    slug: { current: 'sanity-rails-headless-cms' },
+    excerpt: 'Real-world setup of Sanity as a headless CMS for a Rails API — GROQ queries, webhooks for cache invalidation, and live preview setup.',
+    publishedAt: '2025-05-05T09:00:00Z',
+    readTime: 10,
+    featured: false,
+    categories: [
+      { _id: 'c2', title: 'Ruby on Rails', slug: 'ruby-on-rails', color: '#CC0000' },
+      { _id: 'c6', title: 'CMS', slug: 'cms', color: '#F03E2F' },
+    ],
+    author: { _id: 'a1', name: 'Arshdeep Singh', slug: 'arshdeep-singh' },
+  },
+  {
+    _id: '5',
+    title: 'Leading a Dev Team: Sprint Planning & Code Review That Works',
+    slug: { current: 'dev-team-sprint-planning' },
+    excerpt: 'Lessons from growing from intern to Lead Developer — how we run Agile sprints, what makes code reviews effective, and how to mentor without micromanaging.',
+    publishedAt: '2025-04-12T09:00:00Z',
+    readTime: 9,
+    featured: false,
+    categories: [
+      { _id: 'c7', title: 'Leadership', slug: 'leadership', color: '#7C3AED' },
+      { _id: 'c8', title: 'Career', slug: 'career', color: '#ff7955' },
+    ],
+    author: { _id: 'a1', name: 'Arshdeep Singh', slug: 'arshdeep-singh' },
+  },
+  {
+    _id: '6',
+    title: 'Get Started with AI: From Prompt Engineering to Real Projects',
+    slug: { current: 'get-started-with-ai' },
+    excerpt: 'A practical intro to AI tools for developers — prompt patterns, API integration, and how to go from curiosity to shipping something useful.',
+    publishedAt: '2025-03-01T09:00:00Z',
+    readTime: 6,
+    featured: false,
+    categories: [
+      { _id: 'c9', title: 'AI', slug: 'ai', color: '#059669' },
+      { _id: 'c8', title: 'Career', slug: 'career', color: '#ff7955' },
+    ],
+    author: { _id: 'a1', name: 'Arshdeep Singh', slug: 'arshdeep-singh' },
+  },
+];

--- a/projects/blogs/src/app/services/sanity.service.ts
+++ b/projects/blogs/src/app/services/sanity.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { Post, Category, Author } from '@models/post.model';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class SanityService {
+  private readonly baseUrl = `https://${environment.sanityProjectId}.api.sanity.io/v${environment.sanityApiVersion}/data/query/${environment.sanityDataset}`;
+
+  // URL for Sanity image assets
+  imageUrl(ref: string, width = 800): string {
+    if (!ref) return '';
+    // ref format: image-{id}-{dims}-{ext}
+    const [, id, dims, ext] = ref.split('-');
+    return `https://cdn.sanity.io/images/${environment.sanityProjectId}/${environment.sanityDataset}/${id}-${dims}.${ext}?w=${width}&auto=format`;
+  }
+
+  constructor(private http: HttpClient) {}
+
+  private query<T>(groq: string): Observable<T> {
+    const url = `${this.baseUrl}?query=${encodeURIComponent(groq)}`;
+    return this.http.get<{ result: T }>(url).pipe(
+      map((res) => res.result),
+      catchError(() => of([] as unknown as T)),
+    );
+  }
+
+  // ── Posts ──────────────────────────────────────────
+  getPosts(): Observable<Post[]> {
+    return this.query<Post[]>(`
+      *[_type == "post"] | order(publishedAt desc) {
+        _id, title, slug, excerpt, publishedAt, readTime, featured, coverImage,
+        categories[]->{ _id, title, slug, color },
+        author->{ _id, name, slug, image }
+      }
+    `);
+  }
+
+  getFeaturedPost(): Observable<Post | null> {
+    return this.query<Post[]>(`
+      *[_type == "post" && featured == true] | order(publishedAt desc)[0..0] {
+        _id, title, slug, excerpt, publishedAt, readTime, coverImage,
+        categories[]->{ _id, title, slug, color },
+        author->{ _id, name, slug }
+      }
+    `).pipe(map((posts) => posts[0] ?? null));
+  }
+
+  getPostBySlug(slug: string): Observable<Post | null> {
+    return this.query<Post[]>(`
+      *[_type == "post" && slug.current == "${slug}"] {
+        _id, title, slug, excerpt, publishedAt, updatedAt, readTime, featured, coverImage, body,
+        categories[]->{ _id, title, slug, color },
+        author->{ _id, name, slug, image, bio }
+      }
+    `).pipe(map((posts) => posts[0] ?? null));
+  }
+
+  getPostsByCategory(slug: string): Observable<Post[]> {
+    return this.query<Post[]>(`
+      *[_type == "post" && "${slug}" in categories[]->slug.current] | order(publishedAt desc) {
+        _id, title, slug, excerpt, publishedAt, readTime, coverImage,
+        categories[]->{ _id, title, slug, color },
+        author->{ _id, name, slug }
+      }
+    `);
+  }
+
+  // ── Categories ────────────────────────────────────
+  getCategories(): Observable<Category[]> {
+    return this.query<Category[]>(`*[_type == "category"] | order(title asc) { _id, title, slug, color }`);
+  }
+}

--- a/projects/blogs/src/environments/environment.prod.ts
+++ b/projects/blogs/src/environments/environment.prod.ts
@@ -1,0 +1,7 @@
+export const environment = {
+  production: true,
+  sanityProjectId: 'YOUR_PROJECT_ID',   // Set in Vercel env vars as SANITY_PROJECT_ID
+  sanityDataset: 'production',
+  sanityApiVersion: '2025-01-01',
+  sanityUseCdn: true,
+};

--- a/projects/blogs/src/environments/environment.ts
+++ b/projects/blogs/src/environments/environment.ts
@@ -1,0 +1,7 @@
+export const environment = {
+  production: false,
+  sanityProjectId: 'YOUR_PROJECT_ID',   // Replace after: sanity init
+  sanityDataset: 'production',
+  sanityApiVersion: '2025-01-01',
+  sanityUseCdn: false,
+};

--- a/projects/blogs/src/index.html
+++ b/projects/blogs/src/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="utf-8" />
+  <title>Arshdeep Singh — Blog</title>
+  <base href="/" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Technical articles on Angular, Ruby on Rails, full-stack development, and engineering leadership by Arshdeep Singh." />
+  <meta name="author" content="Arshdeep Singh" />
+  <meta name="theme-color" content="#FF7955" />
+  <meta property="og:title" content="Arshdeep Singh — Blog" />
+  <meta property="og:description" content="Angular, Rails &amp; everything in between." />
+  <meta property="og:url" content="https://blogs.arshdeepgrover.dev/" />
+  <meta property="og:image" content="https://arshdeepgrover.dev/images/arshdeep-singh.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:creator" content="@ArshdeepGroverS" />
+  <link rel="canonical" href="https://blogs.arshdeepgrover.dev/" />
+  <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    "name": "Arshdeep Singh — Blog",
+    "url": "https://blogs.arshdeepgrover.dev/",
+    "description": "Technical articles on Angular, Ruby on Rails, and engineering by Arshdeep Singh",
+    "author": {
+      "@type": "Person",
+      "name": "Arshdeep Singh",
+      "url": "https://arshdeepgrover.dev",
+      "sameAs": ["https://linkedin.com/in/ArshdeepGrover", "https://github.com/ArshdeepGrover"]
+    }
+  }
+  </script>
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/projects/blogs/src/main.ts
+++ b/projects/blogs/src/main.ts
@@ -1,0 +1,5 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { appConfig } from './app/app.config';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/projects/blogs/src/styles.scss
+++ b/projects/blogs/src/styles.scss
@@ -1,0 +1,18 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { font-size: 16px; scroll-behavior: smooth; }
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0a0a0a;
+  color: rgba(255, 255, 255, 0.85);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  min-height: 100vh;
+}
+
+a { color: inherit; }
+img { max-width: 100%; display: block; }
+button { font-family: inherit; }

--- a/projects/blogs/tsconfig.app.json
+++ b/projects/blogs/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/blogs",
+    "types": [],
+    "paths": {
+      "@shared/*": ["shared/*"],
+      "@models/*": ["projects/blogs/src/app/models/*"],
+      "@services/*": ["projects/blogs/src/app/services/*"]
+    }
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts",
+    "../../shared/**/*.ts"
+  ]
+}

--- a/projects/blogs/vercel.json
+++ b/projects/blogs/vercel.json
@@ -1,0 +1,15 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "X-XSS-Protection", "value": "1; mode=block" }
+      ]
+    }
+  ]
+}

--- a/projects/links/src/app/stores/links_store.ts
+++ b/projects/links/src/app/stores/links_store.ts
@@ -232,4 +232,15 @@ export const links: ILink[] = [
     description: 'My speaker profile & talks',
     show: false,
   },
+  {
+    id: 24,
+    title: 'Blog',
+    url: 'https://blogs.arshdeepgrover.dev',
+    icon: 'https://www.google.com/s2/favicons?domain=blogs.arshdeepgrover.dev&sz=128',
+    iconType: 'image',
+    brandColor: '#ff7955',
+    category: 'content',
+    description: 'Technical articles on Angular, Rails & more',
+    show: true,
+  },
 ];


### PR DESCRIPTION
NEW — projects/blogs (Angular 18 standalone app)
- Full blog frontend for blogs.arshdeepgrover.dev
- Listing page: featured post card, category filter pills, 3-col post grid
- Post detail: portable text renderer, reading time, share button, code blocks
- Tags page: category cards with post counts
- Dark theme matching portfolio (#0a0a0a bg, #ff7955 accent)
- Demo mode: shows 6 real mock posts when Sanity is not yet connected
- SanityService: GROQ queries for posts, single post, category filter
- PortableTextPipe: renders Sanity block content → safe HTML (h2-h4, quotes, code, links, images)
- HttpClient with fetch-based transport (SSR-ready)
- View transitions API enabled on router

NEW — projects/blogs-studio (Sanity Studio v3)
- sanity.config.ts with structureTool + visionTool
- Schemas: post (title, slug, body, cover, categories, readTime, SEO fields, code blocks)
- Schemas: author (name, slug, image, bio)
- Schemas: category (title, slug, color hex)
- README with 5-min setup guide, CORS instructions, GROQ cheatsheet

CONFIG
- angular.json: blogs project registered (mirrors links config)
- projects/blogs/vercel.json: SPA rewrite rules + security headers
- links_store: blog link added (id 24, category: content)