### PR TITLE
feat(links): add per-card copy button with UTM stripping

### DIFF
--- a/projects/links/src/app/components/home/home.component.html
+++ b/projects/links/src/app/components/home/home.component.html
@@ -133,17 +133,52 @@
           <span class="link-title">{{ link.title }}</span>
           <span class="link-description">{{ link.description }}</span>
         </div>
-        <svg
-          class="link-arrow"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path d="M5 12h14M12 5l7 7-7 7" />
-        </svg>
+        <div class="card-actions">
+          <button
+            class="copy-btn"
+            [class.copied]="copiedId === link.id"
+            (click)="copyLink(link.url, link.id, $event)"
+            aria-label="Copy link"
+            title="Copy link"
+          >
+            <!-- Clipboard icon (idle) -->
+            <svg
+              *ngIf="copiedId !== link.id"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="9" y="2" width="6" height="4" rx="1" />
+              <path d="M9 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V4a2 2 0 00-2-2h-3" />
+            </svg>
+            <!-- Checkmark icon (copied) -->
+            <svg
+              *ngIf="copiedId === link.id"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          </button>
+          <svg
+            class="link-arrow"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M5 12h14M12 5l7 7-7 7" />
+          </svg>
+        </div>
       </a>
     </div>
   </div>

--- a/projects/links/src/app/components/home/home.component.scss
+++ b/projects/links/src/app/components/home/home.component.scss
@@ -590,6 +590,59 @@
   color: rgba(255, 255, 255, 0.4);
 }
 
+.card-actions {
+  @apply flex items-center gap-2 flex-shrink-0;
+}
+
+.copy-btn {
+  @apply w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0;
+  @apply transition-all duration-200 cursor-pointer;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.35);
+  opacity: 0;
+  transform: scale(0.85);
+
+  svg {
+    @apply w-3.5 h-3.5;
+    transition: transform 0.2s ease;
+  }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.8);
+
+    svg {
+      transform: scale(1.1);
+    }
+  }
+
+  &.copied {
+    background: color-mix(in srgb, var(--brand, #7c3aed) 20%, transparent);
+    border-color: color-mix(in srgb, var(--brand, #7c3aed) 40%, transparent);
+    color: color-mix(in srgb, var(--brand, #7c3aed) 90%, white);
+
+    svg {
+      transform: scale(1.15);
+    }
+  }
+}
+
+// Show copy button when card is hovered
+.link-card:hover .copy-btn {
+  opacity: 1;
+  transform: scale(1);
+}
+
+// Always visible on touch devices (no hover)
+@media (hover: none) {
+  .copy-btn {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 .link-arrow {
   @apply w-4 h-4 flex-shrink-0 transition-all duration-300;
   color: rgba(255, 255, 255, 0.15);

--- a/projects/links/src/app/components/home/home.component.ts
+++ b/projects/links/src/app/components/home/home.component.ts
@@ -73,6 +73,7 @@ export class HomeComponent implements AfterViewInit, OnDestroy, OnInit {
   };
 
   shareStatus: 'idle' | 'copied' = 'idle';
+  copiedId: number | null = null;
   searchQuery = '';
 
   visibleLinks = links
@@ -185,6 +186,32 @@ export class HomeComponent implements AfterViewInit, OnDestroy, OnInit {
         (card as HTMLElement).style.animation = `cardSlideIn 0.6s ease both`;
       });
     }, 100);
+  }
+
+  async copyLink(url: string, id: number, event: MouseEvent): Promise<void> {
+    event.preventDefault();
+    event.stopPropagation();
+
+    // Strip UTM params
+    try {
+      const parsed = new URL(url);
+      parsed.searchParams.forEach((_, key) => {
+        if (key.startsWith('utm_')) parsed.searchParams.delete(key);
+      });
+      url = parsed.toString();
+    } catch {
+      // fallback: use url as-is
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      this.copiedId = id;
+      setTimeout(() => {
+        if (this.copiedId === id) this.copiedId = null;
+      }, 2000);
+    } catch (err) {
+      console.error('Copy failed', err);
+    }
   }
 
   async onShare(): Promise<void> {


### PR DESCRIPTION
- Copy button appears on hover (always visible on touch)
- Clipboard icon → checkmark on success, resets after 2s
- Strips all utm_* params before writing to clipboard
- Styled with glassmorphism + brand-color glow on copied state
- Button clicks stopPropagation so card nav doesn't fire